### PR TITLE
fix: correct documentation errors in README.md and vote-receipt-cards…

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ All tokens are deployed as separate contracts via minimal proxy clones. The DAO 
 ### Ragequit
 The defining feature of Moloch-style DAOs: **members can always exit**.
 
-Burn your shares/loot → receive your proportional share of the treasury. Own 10% of shares? Claim 10% of every treasury token. This creates a floor price for membership and protects minorities from majority tyranny.
+Burn your shares/loot → receive your proportional share of the treasury. Own 10% of total (shares + loot)? Claim 10% of every treasury token. This creates a floor price for membership and protects minorities from majority tyranny.
 
 *Limitation: You can only claim external tokens (ETH, USDC, etc.) — not the DAO's own shares, loot, or badges.*
 
@@ -76,8 +76,8 @@ Burn your shares/loot → receive your proportional share of the treasury. Own 1
 Skin-in-the-game governance through prediction markets:
 
 1. Anyone funds a reward pool for a proposal
-2. Vote YES, NO, or ABSTAIN → receive receipt tokens
-3. Proposal passes → YES voters split the pool; fails → NO voters win
+2. Vote FOR, AGAINST, or ABSTAIN → receive receipt tokens
+3. Proposal passes → FOR voters split the pool; fails → AGAINST voters win
 4. Burn your receipts to claim winnings
 
 This shifts incentives from "vote with the crowd" to "vote for what you believe will actually succeed."
@@ -108,7 +108,7 @@ Unopened → Active → Succeeded → Queued (if timelock) → Executed
 **Pass conditions** (all must be true):
 - Quorum reached (absolute or percentage)
 - FOR > AGAINST (ties fail)
-- Minimum YES threshold met (if configured)
+- Minimum FOR votes threshold met (if configured)
 - Not expired
 
 ## Visual Card Examples
@@ -147,7 +147,7 @@ Moloch dao = summoner.summon(
     "",               // URI (metadata)
     5000,             // 50% quorum (basis points)
     true,             // ragequittable
-    address(0),       // renderer (0 = default on-chain SVG)
+    address(0),       // renderer (0 = default on-chain SVG renderer)
     bytes32(0),       // salt (for deterministic addresses)
     holders,          // initial holders
     shares,           // initial shares
@@ -189,16 +189,17 @@ dao.shares().clearSplitDelegation();
 ### Futarchy Markets
 
 ```solidity
-// Fund a prediction market for a proposal
-dao.fundFutarchy(
+// Fund a prediction market for a proposal (ETH)
+dao.fundFutarchy{value: 1 ether}(
     proposalId,
     address(0),  // 0 = ETH, or token address
-    1 ether      // amount
+    1 ether      // amount (must match msg.value for ETH)
 );
 
 // After resolution, claim winnings
-uint256 receiptId = dao._receiptId(proposalId, 1); // 1=YES
-dao.cashOutFutarchy(proposalId, myReceiptBalance);
+// Receipt ID = keccak256("Moloch:receipt", proposalId, support)
+uint256 receiptId = uint256(keccak256(abi.encodePacked("Moloch:receipt", proposalId, uint8(1))));
+dao.cashOutFutarchy(proposalId, dao.balanceOf(msg.sender, receiptId));
 ```
 
 ### Token Sales
@@ -416,9 +417,9 @@ Inspired by Vitalik's DAICO concept — controlled fundraising with investor pro
 // 1. DAO configures a sale
 dao.executeByVotes(...); // calls DAICO.setSaleWithTap(...)
 
-// 2. Users buy shares/loot
-daico.buy(dao, address(0), 1 ether, minShares);  // exact-in
-daico.buyExactOut(dao, address(0), 1000e18, maxPay);  // exact-out
+// 2. Users buy shares/loot (ETH example - must send value)
+daico.buy{value: 1 ether}(dao, address(0), 1 ether, minShares);  // exact-in
+daico.buyExactOut{value: maxPay}(dao, address(0), 1000e18, maxPay);  // exact-out
 
 // 3. Ops team claims vested funds via tap
 daico.claimTap(dao);  // anyone can trigger, funds go to ops
@@ -694,7 +695,7 @@ dao.ragequit(tokens, myShares, 0);
 **A:** Yes! Specify how many shares/loot to burn. You don't have to exit completely.
 
 ### Q: How are proposal IDs generated?
-**A:** Deterministically from: `keccak256(dao, op, to, value, data, nonce, config)`. Anyone can compute it.
+**A:** Deterministically from: `keccak256(abi.encode(dao, op, to, value, keccak256(data), nonce, config))`. Note that `data` is hashed. Anyone can compute it off-chain.
 
 ### Q: What prevents vote buying?
 **A:** Snapshots at block N-1. You can't buy tokens after seeing a proposal and vote.

--- a/assets/vote-receipt-cards.svg
+++ b/assets/vote-receipt-cards.svg
@@ -9,7 +9,7 @@
   <g transform='translate(0,20)'>
     <rect x='20' y='20' width='380' height='560' fill='none' stroke='#0f0' stroke-width='1'/>
     <text x='210' y='55' class='g' font-size='18' fill='#fff' text-anchor='middle'>MAJEUR DAO</text>
-    <text x='210' y='75' class='g' font-size='11' fill='#fff' text-anchor='middle'>VOTE RECE%PT</text>
+    <text x='210' y='75' class='g' font-size='11' fill='#fff' text-anchor='middle'>VOTE RECEIPT</text>
     <line x1='40' y1='90' x2='380' y2='90' stroke='#fff' stroke-width='1'/>
     
     <!-- YES hand -->
@@ -45,7 +45,7 @@
     
     <text x='60' y='292' class='m' font-size='9' fill='#fff'>1234...5678</text>
     <text x='60' y='345' class='g' font-size='14' fill='#f00'>NO</text>
-    <text x='60' y='395' class='m' font-size='9' fill='#fff'>5 000 votes</text>
+    <text x='60' y='395' class='m' font-size='9' fill='#fff'>5,000 votes</text>
     <text x='210' y='510' class='g' font-size='12' fill='#f00' text-anchor='middle'>SEALED</text>
   </g>
   
@@ -53,7 +53,7 @@
   <g transform='translate(880,20)'>
     <rect x='20' y='20' width='380' height='560' fill='none' stroke='#aaa' stroke-width='1'/>
     <text x='210' y='55' class='g' font-size='18' fill='#fff' text-anchor='middle'>MAJEUR DAO</text>
-    <text x='210' y='75' class='g' font-size='11' fill='#fff' text-anchor='middle'>VOTE%RECE%PT</text>
+    <text x='210' y='75' class='g' font-size='11' fill='#fff' text-anchor='middle'>VOTE RECEIPT</text>
     <line x1='40' y1='90' x2='380' y2='90' stroke='#fff' stroke-width='1'/>
     
     <!-- Circle -->


### PR DESCRIPTION
….svg

README.md fixes:

- Fix futarchy example that called internal function `_receiptId` externally. The function is declared as `internal` in Moloch.sol:962, so cannot be called from outside the contract. Replaced with manual keccak256 computation: `uint256(keccak256(abi.encodePacked("Moloch:receipt", proposalId, uint8(1))))`

- Add missing `{value: ...}` to ETH payment examples:
  - `fundFutarchy` now shows `dao.fundFutarchy{value: 1 ether}(...)`
  - DAICO `buy` now shows `daico.buy{value: 1 ether}(...)`
  - DAICO `buyExactOut` now shows `daico.buyExactOut{value: maxPay}(...)` Without these, ETH transfers would fail as msg.value would be 0.

- Clarify ragequit calculation: "10% of shares" → "10% of total (shares + loot)" The actual calculation in Moloch.sol:772 uses `_shares.totalSupply() + _loot.totalSupply()` as the denominator, so loot holdings affect the proportional claim.

- Standardize vote terminology to FOR/AGAINST/ABSTAIN (was using YES/NO inconsistently)
  - "Vote YES, NO, or ABSTAIN" → "Vote FOR, AGAINST, or ABSTAIN"
  - "YES voters split the pool" → "FOR voters split the pool"
  - "Minimum YES threshold" → "Minimum FOR votes threshold"

- Fix FAQ proposal ID hash description to show that `data` is hashed: Was: `keccak256(dao, op, to, value, data, nonce, config)` Now: `keccak256(abi.encode(dao, op, to, value, keccak256(data), nonce, config))`

- Clarify renderer comment: "0 = default on-chain SVG" → "0 = default on-chain SVG renderer"

vote-receipt-cards.svg fixes:

- Fix "VOTE RECEIPT" text corruption on YES and ABSTAIN cards:
  - YES card: "VOTE RECE%PT" → "VOTE RECEIPT"
  - ABSTAIN card: "VOTE%RECE%PT" → "VOTE RECEIPT"

- Fix number format inconsistency on NO card:
  - "5 000 votes" → "5,000 votes" (match comma format used elsewhere)